### PR TITLE
refactor: Update chat service and LLM response structure

### DIFF
--- a/apps/api/src/services/chatService.ts
+++ b/apps/api/src/services/chatService.ts
@@ -1,4 +1,4 @@
-import { query, Request } from 'express';
+import { Request } from 'express';
 import { ChatRequest, ChatResponse } from '../types/chat';
 import { matchDocuments } from './documentService';
 import { generateResponse } from './llmService';

--- a/apps/api/src/services/chatService.ts
+++ b/apps/api/src/services/chatService.ts
@@ -1,18 +1,18 @@
-import { Request } from 'express';
+import { query, Request } from 'express';
 import { ChatRequest, ChatResponse } from '../types/chat';
 import { matchDocuments } from './documentService';
 import { generateResponse } from './llmService';
 
 export async function processChatRequest(query: string, limit: number): Promise<ChatResponse> {
   // Search for relevant documents
-  const matches = await matchDocuments(query, limit);
+  const matches = await matchDocuments(query, limit * 3);
 
   // Generate response using the search results
-  const answer = await generateResponse(query, matches);
+  const { answer, essays } = await generateResponse(query, matches, limit);
   
   return {
     answer,
-    matches
+    essays
   };
 
 } 

--- a/apps/api/src/services/llmService.ts
+++ b/apps/api/src/services/llmService.ts
@@ -38,19 +38,34 @@ const getEssayContent = async (url: string): Promise<string> => {
   return data?.[0]?.content ?? '';
 }
 
-export async function generateResponse(query: string, documents: DocumentMatch[]): Promise<string> {
+export async function generateResponse(
+  query: string, 
+  documents: DocumentMatch[], 
+  limit: number
+) : Promise<{ answer: string, essays: DocumentMatch[] }> {
   try {
-    console.log('Query:', query);
-    console.log('Documents:', JSON.stringify(documents, null, 2));
+    // Remove duplicate documents based on URL
+    const uniqueDocuments = documents.reduce((acc: DocumentMatch[], currentDoc) => {
+      const isDuplicate = acc.some(doc => doc.metadata.source === currentDoc.metadata.source);
+      if (!isDuplicate) {
+        acc.push(currentDoc);
+      }
+      return acc;
+    }, [])
+      .slice(0, limit);
+
+    // uniqueDocuments.forEach((doc, i) => {
+    //   console.log(`Unique Document ${i}: ${doc.metadata.source} - ${doc.metadata.title}`);
+    // });
+
     // Create a prompt that includes the relevant documents
-    const context = documents
+    const context = uniqueDocuments
       .map((doc: DocumentMatch) => `Essay Title: ${doc.metadata.title}\nEssay URL: ${doc.metadata.source}\nEssay Content: ${getEssayContent(doc.pageContent)}`)
       .join('\n\n');
 
-    const essayList = documents
+    const essayList = uniqueDocuments
       .map((doc: DocumentMatch) => `  * [${doc.metadata.title}](${doc.metadata.source})`)
       .join('\n');
-    console.log('Context:', context);
 
     const prompt = `You are an AI assistant helping users explore Paul Graham's essays. 
     Use the following context from relevant essays to answer the user's question.
@@ -72,13 +87,15 @@ export async function generateResponse(query: string, documents: DocumentMatch[]
 
     Answer:`;
 
-    console.log('Prompt:', prompt);
 
     // Generate the response
     const response = await llm.invoke(prompt);
     const answer = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
 
-    return `## Relevant Essays\n${essayList}\n${answer}\n`;
+    return {
+      answer: `## Relevant Essays\n${essayList}\n${answer}\n`,
+      essays: uniqueDocuments
+    };
   } catch (error) {
     console.error('Error generating response:', error);
     throw error;

--- a/apps/api/src/services/llmService.ts
+++ b/apps/api/src/services/llmService.ts
@@ -60,7 +60,7 @@ export async function generateResponse(
 
     // Create a prompt that includes the relevant documents
     const context = uniqueDocuments
-      .map((doc: DocumentMatch) => `Essay Title: ${doc.metadata.title}\nEssay URL: ${doc.metadata.source}\nEssay Content: ${getEssayContent(doc.pageContent)}`)
+      .map((doc: DocumentMatch) => `Essay Title: ${doc.metadata.title}\nEssay URL: ${doc.metadata.source}\nEssay Content: ${getEssayContent(doc.metadata.source)}`)
       .join('\n\n');
 
     const essayList = uniqueDocuments

--- a/apps/api/src/types/chat.ts
+++ b/apps/api/src/types/chat.ts
@@ -8,5 +8,5 @@ export interface ChatRequest {
 
 export interface ChatResponse {
   answer: string;
-  matches: DocumentMatch[];
+  essays: DocumentMatch[];
 }


### PR DESCRIPTION
This commit refactors the `processChatRequest` function in `chatService.ts` to adjust the document matching limit and modifies the response structure to return essays instead of matches. Additionally, the `generateResponse` function in `llmService.ts` is updated to handle unique documents and return a structured response containing both the answer and the list of essays. The `ChatResponse` interface in `chat.ts` is also updated to reflect these changes.